### PR TITLE
3 times speed-up of VBMicrolensing

### DIFF
--- a/VBMicrolensing/lib/VBMicrolensingLibrary.h
+++ b/VBMicrolensing/lib/VBMicrolensingLibrary.h
@@ -27,7 +27,7 @@ class _sols;
 class _theta;
 class complex;
 struct annulus;
-
+/*
 class complex {
 public:
 	double re;
@@ -36,6 +36,17 @@ public:
 	complex(double);
 	complex(void);
 };
+*/
+class complex {
+public:
+	double re;
+	double im;
+	complex(double a, double b) {re = a; im = b; }
+	complex(double a)           {re = a; im = 0; }
+	complex(void)               {re = 0; im = 0; }
+};
+
+
 #ifndef __unmanaged
 namespace VBMicrolensingLibrary {
 

--- a/VBMicrolensing/lib/VBMicrolensingLibrary.h
+++ b/VBMicrolensing/lib/VBMicrolensingLibrary.h
@@ -20,7 +20,8 @@
 #define _sign(x) ((x>0)? +1 : -1)
 
 #include<stdio.h>
-
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 class _curve;
 class _sols;

--- a/VBMicrolensing/lib/VBMicrolensingLibrary.h
+++ b/VBMicrolensing/lib/VBMicrolensingLibrary.h
@@ -340,6 +340,7 @@ public:
 
 #endif
 
+/*
 double abs(complex);
 double abs2(complex);
 complex conj(complex);
@@ -371,3 +372,152 @@ complex operator/(complex, int);
 complex operator-(complex);
 bool operator==(complex, complex);
 bool operator!=(complex, complex);
+*/
+
+//////////////////////////////
+//////////////////////////////
+////////complex methods and operators
+//////////////////////////////
+//////////////////////////////
+
+
+
+
+inline double abs2(complex z) {
+	return (z.re*z.re + z.im*z.im);
+}
+
+inline double abs(complex z) {
+	return sqrt(z.re*z.re + z.im*z.im);
+}
+
+inline complex conj(complex z) {
+	return complex(z.re, -z.im);
+}
+
+inline complex sqrt(complex z) {
+	double md = sqrt(z.re*z.re + z.im*z.im);
+	return (md>0) ? complex((sqrt((md + z.re) / 2)*((z.im>0) ? 1 : -1)), sqrt((md - z.re) / 2)) : 0.0;
+}
+
+inline double real(complex z) {
+	return z.re;
+}
+
+inline double imag(complex z) {
+	return z.im;
+}
+
+inline complex operator+(complex p1, complex p2) {
+	return complex(p1.re + p2.re, p1.im + p2.im);
+}
+
+inline complex operator-(complex p1, complex p2) {
+	return complex(p1.re - p2.re, p1.im - p2.im);
+}
+
+inline complex operator*(complex p1, complex p2) {
+	return complex(p1.re*p2.re - p1.im*p2.im, p1.re*p2.im + p1.im*p2.re);
+}
+
+inline complex operator/(complex p1, complex p2) {
+	double md = p2.re*p2.re + p2.im*p2.im;
+	return complex((p1.re*p2.re + p1.im*p2.im) / md, (p1.im*p2.re - p1.re*p2.im) / md);
+}
+
+inline complex operator+(complex z, double a) {
+	return complex(z.re + a, z.im);
+}
+
+inline complex operator-(complex z, double a) {
+	return complex(z.re - a, z.im);
+}
+
+inline complex operator*(complex z, double a) {
+	return complex(z.re*a, z.im*a);
+}
+
+inline complex operator/(complex z, double a) {
+	return complex(z.re / a, z.im / a);
+}
+
+inline complex operator+(double a, complex z) {
+	return complex(z.re + a, z.im);
+}
+
+inline complex operator-(double a, complex z) {
+	return complex(a - z.re, -z.im);
+}
+
+inline complex operator*(double a, complex z) {
+	return complex(a*z.re, a*z.im);
+}
+
+inline complex operator/(double a, complex z) {
+	double md = z.re*z.re + z.im*z.im;
+	return complex(a*z.re / md, -a * z.im / md);
+}
+
+inline complex operator+(complex z, int a) {
+	return complex(z.re + a, z.im);
+}
+
+inline complex operator-(complex z, int a) {
+	return complex(z.re - a, z.im);
+}
+
+inline complex operator*(complex z, int a) {
+	return complex(z.re*a, z.im*a);
+}
+
+inline complex operator/(complex z, int a) {
+	return complex(z.re / a, z.im / a);
+}
+
+inline complex operator+(int a, complex z) {
+	return complex(z.re + a, z.im);
+}
+
+inline complex operator-(int a, complex z) {
+	return complex(a - z.re, -z.im);
+}
+
+inline complex operator*(int a, complex z) {
+	return complex(a*z.re, a*z.im);
+}
+
+inline complex operator/(int a, complex z) {
+	double md = z.re*z.re + z.im*z.im;
+	return complex(a*z.re / md, -a * z.im / md);
+}
+
+inline complex operator-(complex z) {
+	return complex(-z.re, -z.im);
+}
+
+inline bool operator==(complex p1, complex p2) {
+	if (p1.re == p2.re && p1.im == p2.im) return true;
+	return false;
+}
+
+inline bool operator!=(complex p1, complex p2) {
+	if (p1.re == p2.re && p1.im == p2.im) return false;
+	return true;
+}
+
+inline complex expcmplx(complex p1) {
+	double r = exp(p1.re);
+	double theta = atan2(p1.im, p1.re);
+	return complex(r*cos(theta), r*sin(theta));
+}
+
+inline complex cbrt(complex z) {
+	complex zout;
+	double r, r_cube, theta, theta_cube;
+	r = abs(z);
+	r_cube = pow(r, 0.333333333333);
+	theta = atan2(z.im, z.re);
+	theta_cube = theta / 3.;
+	return 	complex(r_cube*cos(theta_cube), r_cube*sin(theta_cube));
+}
+

--- a/VBMicrolensing/lib/VBclasses.cpp
+++ b/VBMicrolensing/lib/VBclasses.cpp
@@ -441,7 +441,7 @@ void _thetas::remove(_theta* stheta) {
 //////////////////////////////
 //////////////////////////////
 
-
+/*
 complex::complex(double a, double b) {
 	re = a;
 	im = b;
@@ -595,3 +595,4 @@ complex cbrt(complex z) {
 	theta_cube = theta / 3.;
 	return 	complex(r_cube*cos(theta_cube), r_cube*sin(theta_cube));
 }
+*/

--- a/VBMicrolensing/lib/VBpolynomials.cpp
+++ b/VBMicrolensing/lib/VBpolynomials.cpp
@@ -13,7 +13,7 @@
 //////////////////////////////
 
 
-void VBMicrolensing::polyproduct(complex *p1, int n1, complex *p2, int n2, complex *pdest) {
+void VBMicrolensing::polyproduct(complex * __restrict p1, int n1, complex * __restrict p2, int n2, complex * __restrict pdest) {
 	// polynomials are with increasing degree: p1[0]+p1[1]*z+p1[2]*z^2 + ...
 	for (int i = 0; i <= n1 + n2; i++) pdest[i] = 0;
 	for (int i = 0; i <= n1; i++) {
@@ -23,7 +23,7 @@ void VBMicrolensing::polyproduct(complex *p1, int n1, complex *p2, int n2, compl
 	}
 }
 
-void VBMicrolensing::copypol(complex *p1, int n1, complex *pdest) {
+void VBMicrolensing::copypol(complex * __restrict p1, int n1, complex * __restrict pdest) {
 	for (int i = 0; i <= n1; i++) {
 
 		pdest[i] = p1[i];


### PR DESCRIPTION
VBMicrolensing has several source files, and each source file will be compiled into an object file separately. All these object files will then be linked into a shared library. This means compiler can only do optimizations within each single source file. If some functions used in a source file are defined elsewhere, the compiler can not do optimizations as it doesn't know the definition of these functions.
So the most direct way to solve this problem is to put everything into a single source file, just like VBBinaryLensing. Another way (just like these optimizations) is to put the definition instead of the declaration of the frequently used functions (like the complex operation functions) into the header file to make these functions visible to each source file when compiling, thus the compiler can do more optimizations like inlining. 