### PR TITLE
Keplerian orbit calculations with negative ds_z/dt

### DIFF
--- a/VBMicrolensing/lib/VBMicrolensingLibrary.cpp
+++ b/VBMicrolensing/lib/VBMicrolensingLibrary.cpp
@@ -4990,7 +4990,7 @@ void VBMicrolensing::BinaryAstroLightCurveOrbital(double* pr, double* ts, double
 	w123 = sqrt(w13 + w2 * w2);
 	w13 = sqrt(w13);
 	if (w13 > 1.e-8) {
-		w3 = (w3 > 1.e-8) ? w3 : 1.e-8;
+		w3 = (fabs(w3) > 1.e-8) ? w3 : ((w3 < 0.) ? -1.e-8 : 1.e-8);
 		w = w3 * w123 / w13;
 		inc = acos(w2 * w3 / w13 / w123);
 		phi0 = atan2(-w1 * w123, w3 * w13);
@@ -5295,7 +5295,7 @@ void VBMicrolensing::BinSourceBinLensAstroLightCurve(double* pr, double* ts, dou
 	w123 = sqrt(w13 + w2 * w2);
 	w13 = sqrt(w13);
 	if (w13 > 1.e-8) {
-		w3 = (w3 > 1.e-8) ? w3 : 1.e-8;
+		w3 = (fabs(w3) > 1.e-8) ? w3 : ((w3 < 0.) ? -1.e-8 : 1.e-8);
 		w = w3 * w123 / w13;
 		inc = acos(w2 * w3 / w13 / w123);
 		phi0 = atan2(-w1 * w123, w3 * w13);
@@ -5524,7 +5524,7 @@ void VBMicrolensing::TripleAstroLightCurveOrbital(double* pr, double* ts, double
 	w123 = sqrt(w13 + w2 * w2);
 	w13 = sqrt(w13);
 	if (w13 > 1.e-8) {
-		w3 = (w3 > 1.e-8) ? w3 : 1.e-8;
+		w3 = (fabs(w3) > 1.e-8) ? w3 : ((w3 < 0.) ? -1.e-8 : 1.e-8);
 		w = w3 * w123 / w13;
 		inc = acos(w2 * w3 / w13 / w123);
 		phi0 = atan2(-w1 * w123, w3 * w13);
@@ -5789,7 +5789,7 @@ void VBMicrolensing::BinSourceLightCurveXallarap(double* pr, double* ts, double*
 	w123 = sqrt(w13 + w2 * w2);
 	w13 = sqrt(w13);
 	if (w13 > 1.e-8) {
-		w3 = (w3 > 1.e-8) ? w3 : 1.e-8;
+		w3 = (fabs(w3) > 1.e-8) ? w3 : ((w3 < 0.) ? -1.e-8 : 1.e-8);
 		w = w3 * w123 / w13;
 		inc = acos(w2 * w3 / w13 / w123);
 		phi0 = atan2(-w1 * w123, w3 * w13);


### PR DESCRIPTION
When user provided ds_z/dt (i.e., w3) smaller than 0 it was replaced by 1.e-8 and the resulted in incorrect calculation of the orbit parameters. This is now fixed and both positive and negative values are allowed.

This PR was inspired by work done by @mjmroz.